### PR TITLE
fix: used utc instead of local timezone

### DIFF
--- a/src/common/help-functions.js
+++ b/src/common/help-functions.js
@@ -10,4 +10,4 @@ export const saveSettings = (settings) => {
   connectors[2].idTag = settings?.mainSettings.RFIDTag
 }
 
-export const OCPPDate = (date) => moment(date).format('YYYY-MM-DDTHH:mm:ss').toString() + 'Z'
+export const OCPPDate = (date) => moment.utc(moment(date)).format()


### PR DESCRIPTION
When the OCPP simulator was running on the machine with a non-UTC timezone, the local time will be parsed into UTC time, and that will lead to out of sync timestamp, ended up with validation error on the OCPP server.

The fix uses UTC timestamp and formats into ISO 8601 compliant timestamp.